### PR TITLE
Update rulings.json

### DIFF
--- a/json/rulings.json
+++ b/json/rulings.json
@@ -1382,6 +1382,12 @@
             "author": "Sirlin"
         },
         {
+            "card": "Might of Leaf and Claw",
+            "ruling": "Overpower excess damage and Sparkshot damage don't count as extra instances of combat damage."",
+            "date": "2016-11-07T11:17:00.000Z",
+            "author": "Sharpo"
+        },
+        {
             "card": "Guargum, Eternal Sentinel",
             "ruling": "Guargum can even play an ultimate Growth spell for free. He can play it even if you didn't control him at the start of your turn.",
             "date": "2016-03-04T08:00:00.000Z",


### PR DESCRIPTION
We had a discution in #codex channel on Discord about if overpower and sparkshot counted as an extra instance for Might of Leaf and Claw and sharpo came in to tell us that it didnt.